### PR TITLE
requirements: add aiohttp

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 pyTelegramBotAPI
 openai
 asyncio
+aiohttp


### PR DESCRIPTION
Traceback (most recent call last):
    import aiohttp
ModuleNotFoundError: No module named 'aiohttp'